### PR TITLE
chore: set tsc output path to `tsc_out`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,13 +3,13 @@
     [
       "module-resolver", {
         "alias": {
-          "@config": "./ts_out/config/marmoym-config",
-          "@constants": "./ts_out/constants",
-          "@controllers": "./ts_out/controllers",
-          "@customTypes": "./ts_out/customTypes",
-          "@daos": "./ts_out/daos",
-          "@models": "./ts_out/models",
-          "@src": "./ts_out"
+          "@config": "./tsc_out/config/marmoym-config",
+          "@constants": "./tsc_out/constants",
+          "@controllers": "./tsc_out/controllers",
+          "@customTypes": "./tsc_out/customTypes",
+          "@daos": "./tsc_out/daos",
+          "@models": "./tsc_out/models",
+          "@src": "./tsc_out"
         }
       }
     ]

--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,6 @@ fabric.properties
 yarn.lock
 .idea/
 _backup/
-ts_out/
+tsc_out/
 dist/
 /src/config/marmoym-config

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "description": "marmoym-api",
   "scripts": {
-    "babel": "./node_modules/.bin/babel ./ts_out --out-dir ./dist",
+    "babel": "./node_modules/.bin/babel ./tsc_out --out-dir ./dist",
     "build": "yarn run clean && yarn run tsc && yarn run babel",
-    "clean": "./node_modules/.bin/rimraf ./dist/* ./ts_out/*",
+    "clean": "./node_modules/.bin/rimraf ./dist/* ./tsc_out/*",
     "lint": " ./node_modules/.bin/tslint -t stylish -p ./tsconfig.json",
     "migrate:dev": "yarn run build && NODE_ENV=development node ./dist/database/setup.js --migrate",
     "migrate:prod": "yarn run build && NODE_ENV=production node ./dist/database/setup.js --migrate",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     ],
     "module": "commonjs",  
     "moduleResolution": "node",
-    "outDir": "./ts_out/",
+    "outDir": "./tsc_out/",
     "paths": {
       "@config/*": [
         "src/config/marmoym-config/*"


### PR DESCRIPTION
Fixes https://github.com/marmoym/marmoym-api/issues/231

<!--- 
Thanks for the contribution. We appreciate it.
Be sure to checkout our guideline.
-->
## Related Issues

## Checklist
- [ ] Tested successfully.
- [ ] Titles of commit message and PR are in English.
- [ ] PR number at the title will be removed when `squash and merge`.
- [ ] [Guideline](https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages) is followed. 