### PR TITLE
chore: modify `start:dev` so that it runs `build` in advance

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "rollback:dev": "yarn run build && NODE_ENV=development node ./dist/database/setup.js --rollback",
     "seed:dev": "yarn run build && NODE_ENV=development node ./dist/database/setup.js --seed",
     "setup:dev": "./internals/shell/setup.sh",
-    "start:dev": "NODE_ENV=development ./node_modules/.bin/nodemon ./dist/app.js",
-    "start:dev:debug": "NODE_ENV=development ./node_modules/.bin/nodemon ./dist/app.js --debug",
+    "start:dev": "yarn run build && NODE_ENV=development node ./dist/app.js",
+    "start:dev:debug": "NODE_ENV=development node ./dist/app.js --debug",
     "test": "echo \"Error: no test specified\"",
     "tsc": "./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },
@@ -31,7 +31,6 @@
     "chai": "^4.0.2",
     "mocha": "^3.4.2",
     "morgan": "^1.9.0",
-    "nodemon": "^1.14.12",
     "rimraf": "^2.6.2",
     "tslint": "^5.8.0",
     "typescript": "^2.5.3",


### PR DESCRIPTION
Fixes https://github.com/marmoym/marmoym-api/issues/232

<!--- 
Thanks for the contribution. We appreciate it.
Be sure to checkout our guideline.
-->
## Related Issues

## Checklist
- [ ] Tested successfully.
- [ ] Titles of commit message and PR are in English.
- [ ] PR number at the title will be removed when `squash and merge`.
- [ ] [Guideline](https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages) is followed. 