### PR TITLE
chore: make process quit when typescript compilation fails

### DIFF
--- a/internals/gulp/gulpfile.js
+++ b/internals/gulp/gulpfile.js
@@ -21,7 +21,7 @@ process.chdir('../../');
 console.log('Current working directory %s', process.cwd());
 
 gulp.task('clean', () => {
-  console.log('Remove all the contents in %s', DIST_PATH);
+  console.log('[clean] Remove all the contents in %s', DIST_PATH);
 
   return del([
     `${DIST_PATH}/**/*`,
@@ -29,7 +29,7 @@ gulp.task('clean', () => {
 });
 
 gulp.task('emptylog', () => {
-  console.log('LOG_PATH: %s', LOG_PATH);
+  console.log('[emptylog] LOG_PATH: %s', LOG_PATH);
   
   return del([
     `${LOG_PATH}/**/*`,
@@ -37,16 +37,21 @@ gulp.task('emptylog', () => {
 });
 
 gulp.task('tsc-babel', () => {
-  console.log('DIST_PATH: %s, TSCONFIG_PATH: %s', DIST_PATH, TSCONFIG_PATH);
+  console.log('[tsc-babel] DIST_PATH: %s, TSCONFIG_PATH: %s', DIST_PATH, TSCONFIG_PATH);
 
   const tsProject = ts.createProject(TSCONFIG_PATH);
 
   return tsProject.src()
     .pipe(tsProject())
+    .on('error', (err) => {
+      console.error('[tsc-babel] tsc fails at %s, Process will quit.', err.fullFilename);
+      process.exit();
+    })
     .pipe(sourcemaps.init())
     .pipe(babel())
     .pipe(sourcemaps.write('.'))
-    .pipe(gulp.dest(DIST_PATH));
+    .pipe(gulp.dest(DIST_PATH))
+    
 });
 
 gulp.task('build', gulp.series('clean', 'tsc-babel'));


### PR DESCRIPTION
Fixes https://github.com/marmoym/marmoym/issues/96

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
