### PR TITLE
fix: restore definition add behavior

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,8 @@ import routeNoMatchHandler from '@middlewares/routeNoMatchHandler';
 import routes from '@routes/routes';
 import Token from '@modules/Token';
 
+import httpLogger from '@middlewares/httpLogger';
+
 const APP_LAUNCH_STATUS = {
   NOT_YET_INTIALIZED: 'NOT_YET_INTIALIZED',
   INIT_ERROR: 'INIT_ERROR',
@@ -46,11 +48,11 @@ const state = {
 })();
 
 (function defineApp() {
-  app.use(morgan('tiny'))
-  app.use(corsHandler());
-  app.use(cookieParser());
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());
+  app.use(httpLogger);
+  app.use(corsHandler());
+  app.use(cookieParser());
   app.use((req, res, next) => {
     if (state.appLaunchStatus === APP_LAUNCH_STATUS.NOT_YET_INTIALIZED) {
       res.send({

--- a/src/entities/Definition.ts
+++ b/src/entities/Definition.ts
@@ -43,19 +43,19 @@ export default class Definition extends BaseEntity {
   public vote: Vote;
 
   constructor(param?: {
-    id,
     label,
     term?,
     user?,
-    vote,
   }) {
     super();
     if (param) {
-      this.id = param.id;
       this.label = param.label;
       this.term = param.term;
       this.user = param.user;
-      this.vote = param.vote;
     }
   }
 };
+
+interface DefinitionParam {
+   
+}

--- a/src/entities/Term.ts
+++ b/src/entities/Term.ts
@@ -20,17 +20,13 @@ export default class Term extends BaseEntity {
   public status?: string;
 
   constructor(param?: {
-    id,
     label,
     roman?,
     status?,
   }) {
     super();
-    if (param) {
-      this.id = param.id;
-      this.label = param.label;
-      this.roman = param.roman;
-      this.status = param.status;
-    }
+    this.label = param && param.label;
+    this.roman = param && param.roman;
+    this.status = param && param.status;
   }
 };

--- a/src/middlewares/httpLogger.ts
+++ b/src/middlewares/httpLogger.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from 'express';
+
+import Logger from '@modules/Logger';
+
+const FORMAT = '[%s] url: %s, params: %j, body: %j, headers: %j';
+
+export default function httpLogger(req: Request, res: Response, next: NextFunction) {
+  Logger.info(FORMAT, new Date(), req.url, req.params, req.body, req.headers);
+  next();
+};

--- a/src/migrate/seed/seed.180725.ts
+++ b/src/migrate/seed/seed.180725.ts
@@ -4,84 +4,51 @@ import User from '@entities/User';
 import Vote from '@entities/Vote';
 
 const term1 = new Term({
-  id: 1,
   label: 'term0',
 });
 
 const term2 = new Term({
-  id: 2,
   label: 'term1',
 });
 
 const term3 = new Term({
-  id: 3,
   label: 'term2',
 });
 
 const user1 = new User({
   email: 'user0@email.com',
-  id: 1,
   password: '$2a$10$SKF7vz43Bi/r0PEHgztgYOBhFQMwbcxAUn2JEAR8qTEJBAs7a1f4m',
   username: 'user0',
 });
 
 const user2 = new User({
   email: 'user1@email.com',
-  id: 2,
   password: '$2a$10$SKF7vz43Bi/r0PEHgztgYOBhFQMwbcxAUn2JEAR8qTEJBAs7a1f4m',
   username: 'user1',
 });
 
 const user3 = new User({
   email: 'user2@email.com',
-  id: 3,
   password: '$2a$10$SKF7vz43Bi/r0PEHgztgYOBhFQMwbcxAUn2JEAR8qTEJBAs7a1f4m',
   username: 'user2',
 });
 
-const vote1 = new Vote({
-  downvoteCount: 0,
-  targetId: 1,
-  targetType: 'D',
-  upvoteCount: 0,
-});
-
-const vote2 = new Vote({
-  downvoteCount: 0,
-  targetId: 2,
-  targetType: 'D',
-  upvoteCount: 0,
-});
-
-const vote3 = new Vote({
-  downvoteCount: 0,
-  targetId: 3,
-  targetType: 'D',
-  upvoteCount: 0,
-});
-
 const definition1 = new Definition({
-  id: 1,
   label: 'definition1',
   term: term1,
   user: user1,
-  vote: vote1,
 });
 
 const definition2 = new Definition({
-  id: 2,
   label: 'definition2',
   term: term2,
   user: user2,
-  vote: vote2,
 });
 
 const definition3 = new Definition({
-  id: 3,
   label: 'definition3',
   term: term3,
   user: user3,
-  vote: vote3,
 });
 
 const seedData: {

--- a/src/repositories/DefinitionRepository.ts
+++ b/src/repositories/DefinitionRepository.ts
@@ -5,3 +5,4 @@ import Definition from '@entities/Definition';
 export class DefinitionRepository extends Repository<Definition> {
 
 }
+

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -34,7 +34,7 @@ function registerRouter(app, path, routeMap: Route[]) {
     router[route.method](
       route.path, 
       [
-        ...route.before && route.before || [],
+        ...(route.before && route.before || []),
         (req: Request, res: Response, next: NextFunction) => {
           const param = route.createParam ? route.createParam(req) : null;
           route.action(param)

--- a/src/routes/v1/routeMap.v1.ts
+++ b/src/routes/v1/routeMap.v1.ts
@@ -59,6 +59,7 @@ const pathOrderedRouteMap: Route[] = [
     createParam: (req: Request) => {
       return {
         definition: req.body.definition,
+        term: req.body.definition,
       };
     },
     method: HttpMethod.POST,

--- a/src/services/Definition/definitionService.ts
+++ b/src/services/Definition/definitionService.ts
@@ -12,22 +12,27 @@ import User from '@entities/User';
 
 export default {
   async addDefinition({
-    definitionLabel,
-    termLabel,
+    definition,
+    term,
   }: AddDefinitionParam) {
     try {
       const termRepo = getCustomRepository(TermRepository, DB1);
-      const [ term, count ] = await termRepo.findAndCount({
-        label: termLabel,
+      const [ _term, count ] = await termRepo.findAndCount({
+        label: term,
       });
 
-      // const definition = new Definition({
+      const newDefinition = new Definition({
+        term: _term[0] || new Term({
+          label: term,
+        }),
+        label: definition,
+      });
 
-      // });
+      console.log(123, newDefinition);
 
-      if (count > 0) {
+      const definitionRepo = getCustomRepository(DefinitionRepository, DB1);
+      definitionRepo.save(newDefinition);
 
-      }
       return new ApiResult<{}>({});
     } catch (err) {
       throw err;
@@ -64,8 +69,8 @@ export default {
 };
 
 export interface AddDefinitionParam {
-  definitionLabel: string,
-  termLabel: string,
+  definition: string,
+  term: string,
 };
 
 export interface GetDefinitionsParam {


### PR DESCRIPTION
- httpLogger is created. The middleware immediately writes the detailed information
when the app receives requests. It is defined in the pipeline after bodyParser
so that `req.body` is to be prepared.

Fixes https://github.com/marmoym/marmoym/issues/104

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
