### PR TITLE
feat: make db connection check stricter

### DIFF
--- a/internals/babel/.babelrc.js
+++ b/internals/babel/.babelrc.js
@@ -1,8 +1,4 @@
 module.exports = {
-  "presets": [
-    "@babel/preset-env",
-    "@babel/preset-typescript",
-  ],
   "plugins": [
     [
       "module-resolver", {
@@ -33,5 +29,16 @@ module.exports = {
     "@babel/plugin-syntax-import-meta",
     ["@babel/plugin-proposal-class-properties", { "loose": false }],
     "@babel/plugin-proposal-json-strings"
+  ],
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current",
+        }
+      }
+    ],
+    "@babel/preset-typescript",
   ],
 }

--- a/src/entities/db.ts
+++ b/src/entities/db.ts
@@ -19,6 +19,7 @@ const sequelize = new Sequelize({
   database: dbConfig.database,
   dialect: dbConfig.type,
   host: dbConfig.host,
+  operatorsAliases: false,
   password: dbConfig.password,
   pool: {
     acquire: 30000,
@@ -53,6 +54,21 @@ db.sequelize = sequelize;
 // db.Sequelize = Sequelize;
 
 export default db;
+
+export async function initializeDB(): Promise<boolean> {
+  try {
+    await db.sequelize.authenticate();
+    dbLog.info('authenticate() success, db is connectable');
+
+    await db.sequelize.sync();
+    dbLog.info('sync() success');
+
+    return true;
+  } catch (err) {
+    dbLog.error('db authenticate() fail: %o', err);
+    return false;
+  }
+}
 
 interface DB {
   [entity: string]: any,


### PR DESCRIPTION
- For some reason, sequelize sync() always succeeds even when db credentials
are invalid. We use authenticate() instead.
- db connection initializing logic moved into db.ts.

Fixes https://github.com/marmoym/marmoym/issues/121

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
