### PR TITLE
feat: externalize routeMapper

### DIFF
--- a/internals/babel/.babelrc.js
+++ b/internals/babel/.babelrc.js
@@ -7,6 +7,7 @@ module.exports = {
           "@constants": "./src/constants",
           "@daos": "./src/daos",
           "@entities": "./src/entities",
+          "@externalModules": "./src/externalModules",
           "@middlewares": "./src/middlewares",
           "@models": "./src/models",
           "@modules": "./src/modules",

--- a/src/externalModules/routeMapper/routeMapper.ts
+++ b/src/externalModules/routeMapper/routeMapper.ts
@@ -1,0 +1,66 @@
+import { 
+  Application,
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from 'express';
+import chalk from 'chalk';
+
+export default function routeMapper<R>(app: Application, routeDefinitions: RouteDefinition<R>[]) {
+  routeDefinitions.map((rmap) => {
+    registerRouter(app, rmap.mapPath, rmap.map, rmap.postAsyncHandlers);
+  });
+  return app;
+};
+
+const registerRouter: RegisterRouter = function (app, mapPath, routeMap, postAsyncHandlers) {
+  const router: Router = Router();
+  console.log(`[routeMapper] mapPath: ${chalk.green('%s')}, postAsyncHandlers (%s)`, mapPath, postAsyncHandlers.length);
+
+  routeMap.map((route) => {
+    console.debug('[routeMapper] Route is registered: [%s] %s', route.method, route.path);
+    router[route.method](
+      route.path, 
+      [
+        ...(route.beforeware && route.beforeware || []),
+        (req: Request, res: Response, next: NextFunction) => {
+          const param = route.createParam ? route.createParam(req) : null;
+
+          postAsyncHandlers.reduce((acc, curr) => {
+            return acc.then(curr(req, res, next));
+          }, route.action(param))
+            .catch(next);
+        },
+      ],
+    );
+  });
+  app.use(mapPath, router);
+}
+
+export interface Route<R> {
+  action: (x: object | null) => Promise<R>;
+  beforeware?: Array<(Request, res: Response, next: NextFunction) => void>;
+  createParam?: (req: Request) => object;
+  method: 'get' | 'post' | 'put' | 'delete';
+  path: string;
+}
+
+export interface RegisterRouter {
+  <R>(
+    app: Application, 
+    mapPath: string, 
+    routeMap: Route<R>[], 
+    postAsyncHandlers: Array<PostAsyncHandler<R>>,
+  ): void;
+}
+
+export interface RouteDefinition<R> {
+  map: Route<R>[],
+  mapPath: string;
+  postAsyncHandlers: Array<(req: Request, res: Response, next: NextFunction) => (R: R) => R>,
+}
+
+interface PostAsyncHandler<R> {
+  (req: Request, res: Response, next: NextFunction): (R: R) => R;
+}

--- a/src/middlewares/corsHandler.ts
+++ b/src/middlewares/corsHandler.ts
@@ -6,6 +6,8 @@ import { expressLog } from '@modules/Log';
 import ResponseType from '@models/ResponseType';
 
 export default function corsHandler() {
+  expressLog.info('corsHandler() wtih: %o, ', appConfig.cors);
+
   return [
     // https://github.com/expressjs/cors/issues/71#issuecomment-279661081
     (req, res, next) => {

--- a/src/middlewares/launchStatusChecker.ts
+++ b/src/middlewares/launchStatusChecker.ts
@@ -1,4 +1,9 @@
-import { Handler, Request, Response, NextFunction } from 'express';
+import { 
+  NextFunction,
+  Handler, 
+  Request, 
+  Response, 
+} from 'express';
 
 import LaunchStatus from '@constants/LaunchStatus';
 import ResponseType from '@models/ResponseType';

--- a/src/middlewares/routeNoMatchHandler.ts
+++ b/src/middlewares/routeNoMatchHandler.ts
@@ -8,4 +8,4 @@ export default function routeNoMatchHandlerr(req: Request, res: Response, next: 
   next(AppError.of({
     type: ResponseType.ROUTE_NOT_DEFINED,
   }));
-};
+}

--- a/src/models/ApiURL.ts
+++ b/src/models/ApiURL.ts
@@ -26,6 +26,6 @@ export default class ApiURL {
 };
 
 export const API = {
-  DEFAULT: '',
+  DEFAULT: '/',
   V1: '/api/v1',
 };

--- a/src/models/AppError.ts
+++ b/src/models/AppError.ts
@@ -1,7 +1,7 @@
 import { format } from 'util';
 
-import ResponseType, { 
-  ResponseTypeEntry,
+import Response, { 
+  ResponseEntry,
 } from '@models/ResponseType';
 
 export const VERSION = Symbol('version');
@@ -24,7 +24,7 @@ export default class AppError extends Error {
   }: {
     args?: any[],
     error?: Error,
-    type: ResponseTypeEntry,
+    type: ResponseEntry,
   }) {
     const apiError = new AppError();
     apiError.code = type.code;

--- a/src/models/ResponseType.ts
+++ b/src/models/ResponseType.ts
@@ -1,10 +1,4 @@
-export interface ResponseTypeEntry {
-  code: number;
-  desc: string;
-  label: string;
-};
-
-const ResponseType = {
+const Response = {
   EMAIL_ALREADY_USED: {
     code: 401005,
     desc: 'email already used',
@@ -44,6 +38,11 @@ const ResponseType = {
     code: 404003,
     desc: 'Route is not defined',
     label: 'ROUTE_NOT_DEFINED',
+  },
+  SERVER_INTERNAL_ERROR: {
+    code: 500001,
+    desc: 'Internal Server error',
+    label: 'SERVER_INTERNAL_ERROR',
   },
   SUCCESS: {
     code: 200000,
@@ -107,5 +106,14 @@ const ResponseType = {
   },
 };
 
-export default ResponseType;
+export default Response;
 
+export interface ResponseType {
+  [label: string]: ResponseEntry
+}
+
+export interface ResponseEntry {
+  code: number;
+  desc: string;
+  label: string;
+}

--- a/src/routes/default/routeMap.default.ts
+++ b/src/routes/default/routeMap.default.ts
@@ -3,9 +3,9 @@ import { Router, Request, Response } from 'express';
 import ApiURL from '@models/ApiURL';
 import * as DebugService from '@services/debugService';
 import HttpMethod from '@constants/HttpMethod';
-import { Route } from '../routes';
+// import { Route } from '../routes';
 
-const routeMap: Route[] = [
+const routeMap = [
   {
     action: DebugService.getDebug,
     method: HttpMethod.GET,

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,4 +1,10 @@
-import { Router, Request, Response, NextFunction } from 'express';
+import { 
+  Application,
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from 'express';
 
 import ApiResult from '@models/ApiResult';
 import { API } from '@models/ApiURL';
@@ -8,65 +14,45 @@ import Crypt from '@modules/Crypt';
 import HttpStatus from '@constants/HttpStatus';
 import { expressLog } from '@modules/Log';
 import ResponseType from '@models/ResponseType';
-// import routeMapDefault from './default/routeMap.default';
+import routeMapDefault from './default/routeMap.default';
+import routeMapper from '@externalModules/routeMapper/routeMapper';
 // import routeMap1 from './v1/routeMap.v1';
 
-export interface Route {
-  action: (x: object | null) => Promise<ApiResult<any>>,
-  before?: Array<(Request, res: Response, next: NextFunction) => void>,
-  createParam?: (req: Request) => object,
-  method: 'get' | 'post' | 'put' | 'delete',
-  path: string,
-};
+const routeDefinitions = [
+  {
+    map: routeMapDefault,
+    mapPath: API.DEFAULT,
+    postAsyncHandlers: [
+      respond,
+    ],
+  },
+];
 
-export default function routes(app) {
-  // registerRouter(app, API.DEFAULT, routeMapDefault);
-  // registerRouter(app, API.V1, routeMap1);
-
+export default function routes(app: Application) {
+  routeMapper(app, routeDefinitions);
   return app;
-};
-
-function registerRouter(app, path, routeMap: Route[]) {
-  const router: Router = Router();
-
-  routeMap.map((route) => {
-    expressLog.debug('Route is registered: [%s] %s', route.method, route.path);
-    router[route.method](
-      route.path, 
-      [
-        ...(route.before && route.before || []),
-        (req: Request, res: Response, next: NextFunction) => {
-          const param = route.createParam ? route.createParam(req) : null;
-          route.action(param)
-            .then(validatePayload)
-            .then(setCookie(res))
-            .then(respond(res))
-            .catch(next);
-        },
-      ],
-    );
-  });
-  app.use(path, router);
 }
 
-function validatePayload(apiResult: ApiResult<any>) {
-  if (apiResult === undefined) {
-    throw AppError.of({
-      type: ResponseType.RESPONSE_NOT_PROVIDED,
-    });
-  }
+function validatePayload(req: Request, res: Response, next: NextFunction) {
+  return function (apiResult: ApiResult<any>) {
+    if (apiResult === undefined) {
+      throw AppError.of({
+        type: ResponseType.RESPONSE_NOT_PROVIDED,
+      });
+    }
 
-  if (!(apiResult instanceof ApiResult)) {
-    throw AppError.of({
-      args: [ apiResult ],
-      type: ResponseType.RESPONSE_TYPE_NOT_API_RESULT,
-    });
-  }
+    if (!(apiResult instanceof ApiResult)) {
+      throw AppError.of({
+        args: [ apiResult ],
+        type: ResponseType.RESPONSE_TYPE_NOT_API_RESULT,
+      });
+    }
 
-  return apiResult;
+    return apiResult;
+  }
 }
 
-function setCookie(res: Response) {
+function setCookie(req: Request, res: Response, next: NextFunction) {
   return function (apiResult: ApiResult<any>) {
     const cookies = apiResult.getCookies();
     if (cookies.length > 0) {
@@ -81,15 +67,17 @@ function setCookie(res: Response) {
       });
     }
     return apiResult;
-  };
-};
+  }
+}
 
-function respond(res: Response) {
+function respond(req: Request, res: Response, next: NextFunction) {
   return function (apiResult: ApiResult<any>) {
     res.status(HttpStatus.SUCCESS)
       .send({
         code: ResponseType.SUCCESS.code,
         payload: apiResult,
       });
-  };
+
+    return apiResult;
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
       "@entities/*": [
         "src/entities/*"
       ],
+      "@externalModules/*": [
+        "src/externalModules/*"
+      ],
       "@middlewares/*": [
         "src/middlewares/*"
       ],


### PR DESCRIPTION
- RouteDefinition, PostASyncHandler types are defined. `routeMapper` is expected
to be define as library.
- routes() calls `routeMapper` with routeDefinition.
- `SERVER_INTERNAL_ERROR` Response Type is added.

Fixes https://github.com/marmoym/marmoym/issues/122

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
