### PR TITLE
feat: create external module `middleware-attach`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "typescript": "^3.1.3"
   },
   "dependencies": {
-    "@nodekit/route-mapper": "0.0.2",
+    "@nodekit/node-logger": "git+https://github.com/nodekit-org/node-logger.git",
+    "@nodekit/route-mapper": "git+https://github.com/nodekit-org/route-mapper.git",
     "bcrypt": "^1.0.3",
     "body-parser": "^1.17.1",
     "chalk": "^2.4.1",
@@ -56,7 +57,6 @@
     "express": "^4.16.4",
     "jsonwebtoken": "^7.4.0",
     "ms": "^2.1.1",
-    "node-logger": "git+https://github.com/eldeni/node-logger.git",
     "pg": "^7.4.3",
     "sequelize": "^4.38.0",
     "typeorm": "^0.2.5",

--- a/src/app.middlewares.ts
+++ b/src/app.middlewares.ts
@@ -1,0 +1,52 @@
+import * as bodyParser from "body-parser";
+import cookieParser from 'cookie-parser';
+
+import { API } from '@models/ApiURL';
+import corsHandler from '@middlewares/corsHandler';
+import errorHandler from './middlewares/errorHandler';
+import httpLogger from "@middlewares/httpLogger";
+import launchStatusChecker from '@middlewares/launchStatusChecker';
+import { MiddlewareDefinition } from '@externalModules/middleware-attach'
+import routeNoMatchHandler from '@middlewares/routeNoMatchHandler';
+import routers from '@routes/routers';
+import state from '@src/state';
+
+const middlewareDefinitions: MiddlewareDefinition[] = [
+  {
+    middlewares: [ 
+      bodyParser.urlencoded({ extended: true }),
+      bodyParser.json(),
+    ],
+  },
+  {
+    middlewares: [ httpLogger ],
+  },
+  {
+    middlewares: corsHandler(),
+  },
+  {
+    middlewares: [ errorHandler ],
+  },
+  {
+    middlewares: [ cookieParser() ],
+  },
+  {
+    middlewares: [ launchStatusChecker(state) ],
+  },
+  {
+    middlewares: [ routers.default ],
+    path: API.DEFAULT,
+  },
+  {
+    middlewares: [ routers.v1 ],
+    path: API.V1,
+  },
+  {
+    middlewares: [ routeNoMatchHandler ],
+  },
+  {
+    middlewares: [ errorHandler ],
+  },
+];
+
+export default middlewareDefinitions;

--- a/src/externalModules/middleware-attach/index.ts
+++ b/src/externalModules/middleware-attach/index.ts
@@ -1,0 +1,46 @@
+import {
+  Application,
+  RequestHandler,
+  ErrorRequestHandler,
+  Request,
+  Response,
+  NextFunction,
+} from 'express';
+import chalk from 'chalk';
+
+const middlewareAttach: MiddlewareAttach = function (app, middlewareDefs) {
+  middlewareDefs.map(({ middlewares, path }) => {
+    console.info(
+      `[middleware-attach] middleware is attached at path: ${chalk.yellow('%s')}, middlewares: %s`, 
+      path || 'VOID',
+      getMiddlewareNames(middlewares),
+    );
+    if (path) {
+      app.use(path, middlewares);
+    } else {
+      app.use(middlewares);
+    }
+  });
+};
+
+export default middlewareAttach;
+
+interface MiddlewareAttach {
+  (
+    app: Application, 
+    middlewareDefs: MiddlewareDefinition[],
+  ): void;
+}
+
+export interface MiddlewareDefinition {
+  middlewares: (RequestHandler | ErrorRequestHandler)[];
+  path?: string;
+}
+
+function getMiddlewareNames(middlewares: Function[] | Function): string {
+  if (Array.isArray(middlewares)) {
+    return `[ ${middlewares.map((m) => m.name).join(', ')} ]`; 
+  } else {
+    return middlewares.name;
+  }
+}

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -9,7 +9,7 @@ import ResponseType from '@models/ResponseType';
 
 export default function errorHandler(err, req, res, next) {
   try {
-    expressLog.error('Error at %s, Original cause:\n%o', req.url, err);
+    expressLog.error('[errorHandler] Error at %s, Original cause:\n%o', req.url, err);
 
     if (!(err instanceof Error)) {
       err = AppError.of({
@@ -21,7 +21,7 @@ export default function errorHandler(err, req, res, next) {
       err = ResponseType.RESPONSE_TYPE_NOT_API_RESULT;
     }
 
-    expressLog.error(chalk`Processed API Error {red [%s]} %s`, err.code, err.label);
+    expressLog.error(`[errorHandler] Error determined as ${chalk.red('[%s]')} %s`, err.code, err.label);
 
     res.status(HttpStatus.ERROR)
       .send({

--- a/src/middlewares/launchStatusChecker.ts
+++ b/src/middlewares/launchStatusChecker.ts
@@ -5,11 +5,14 @@ import {
   Response, 
 } from 'express';
 
+import { expressLog } from '@modules/Log';
 import LaunchStatus from '@constants/LaunchStatus';
 import ResponseType from '@models/ResponseType';
-import { State } from '@src/app';
+import { State } from '@src/state';
 
 const launchStatusChecker = (state: State) => {
+  expressLog.info('[launchStatusChecker] create checker with state: %o', state);
+
   return (req: Request, res: Response, next: NextFunction) => {
     if (state.launchStatus === LaunchStatus.NOT_YET_INTIALIZED) {
       res.send({

--- a/src/modules/Log.ts
+++ b/src/modules/Log.ts
@@ -1,5 +1,6 @@
-import * as NodeLogger from 'node-logger';
+import * as NodeLogger from '@nodekit/node-logger';
 
+import chalk from 'chalk';
 import * as paths from '@src/paths';
 
 const nodeLogger = NodeLogger.createLogger({
@@ -9,31 +10,31 @@ const nodeLogger = NodeLogger.createLogger({
 export default nodeLogger;
 
 export const gulpLog = nodeLogger.with({
-  color: 'gray',
+  colorFunction: chalk.gray,
   tag: 'gulp',
 });
 
 export const httpLog = nodeLogger.with({
-  color: 'black',
+  colorFunction: chalk.black,
   tag: 'http',
 });
 
 export const launchLog = nodeLogger.with({
-  color: 'gray',
+  colorFunction: chalk.gray,
   tag: 'launch',
 });
 
 export const dbLog = nodeLogger.with({
-  color: 'magentaBright',
+  colorFunction: chalk.magentaBright,
   tag: 'db',
 });
 
 export const stateLog = nodeLogger.with({
-  color: 'yellowBright',
+  colorFunction: chalk.yellowBright,
   tag: 'server-state',
 });
 
 export const expressLog = nodeLogger.with({
-  color: 'blue',
+  colorFunction: chalk.blue,
   tag: 'express',
 });

--- a/src/routes/routers.ts
+++ b/src/routes/routers.ts
@@ -23,11 +23,12 @@ const apiPostAsyncHandlers = [
   respond,
 ];
 
-export default function routes(app: Application) {
-  app.use(API.DEFAULT, createRouter(routesDefault, [ respond ]));
-  app.use(API.V1, createRouter(routesV1, apiPostAsyncHandlers));
-  return app;
-}
+const routers = {
+  default: createRouter(routesDefault, [ respond ]),
+  v1: createRouter(routesV1, apiPostAsyncHandlers),
+};
+
+export default routers;
 
 function validatePayload(req: Request, res: Response, next: NextFunction) {
   return function (apiResult: ApiResult<any>) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,21 @@
+import LaunchStatus from '@constants/LaunchStatus';
+import { stateLog } from '@modules/Log';
+
+const state: State = {
+  launchStatus: LaunchStatus.NOT_YET_INTIALIZED,
+  update(obj = {}) {
+    stateLog.info('state will update with: %o', obj);
+    for (let key in this) {
+      if (obj[key]) {
+        this[key] = obj[key];
+      }
+    }
+  },
+};
+
+export default state;
+
+export interface State {
+  launchStatus: string,
+  update: (obj: {}) => void,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,6 +736,23 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
+"@nodekit/node-logger@git+https://github.com/nodekit-org/node-logger.git":
+  version "0.0.1"
+  resolved "git+https://github.com/nodekit-org/node-logger.git#6b4472010544cb590a0a8bb19fd2fbdfbbec4935"
+  dependencies:
+    chalk "^2.4.1"
+    triple-beam "^1.3.0"
+    typescript "^3.1.6"
+    winston "^3.1.0"
+    winston-daily-rotate-file "^3.5.1"
+
+"@nodekit/route-mapper@git+https://github.com/nodekit-org/route-mapper.git":
+  version "0.0.2"
+  resolved "git+https://github.com/nodekit-org/route-mapper.git#647aef20a297867d0761d247bbcfb200204011a4"
+  dependencies:
+    "@types/express" "^4.16.0"
+    typescript "^3.1.6"
+
 "@types/body-parser@*":
   version "1.16.8"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.16.8.tgz#687ec34140624a3bec2b1a8ea9268478ae8f3be3"
@@ -772,7 +789,7 @@
     "@types/events" "*"
     "@types/node" "*"
 
-"@types/express@*", "@types/express@^4.11.1":
+"@types/express@*":
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.11.1.tgz#f99663b3ab32d04cb11db612ef5dd7933f75465b"
   integrity sha512-ttWle8cnPA5rAelauSWeWJimtY2RsUf2aspYZs7xPHiWgOlPn6nnUfBMtrkcnjFJuIHJF4gNOdVvpLK2Zmvh6g==
@@ -1245,7 +1262,23 @@ bluebird@^3.4.6, bluebird@^3.5.0:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
   integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
-body-parser@1.18.2, body-parser@^1.17.1:
+body-parser@1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
+  integrity sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=
+  dependencies:
+    bytes "3.0.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "~1.6.3"
+    iconv-lite "0.4.23"
+    on-finished "~2.3.0"
+    qs "6.5.2"
+    raw-body "2.3.3"
+    type-is "~1.6.16"
+
+body-parser@^1.17.1:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
   integrity sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=
@@ -2203,14 +2236,14 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-express@^4.16.3:
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
-  integrity sha1-avilAjUNsyRuzEvs9rWjTSL37VM=
+express@^4.16.4:
+  version "4.16.4"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
+  integrity sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==
   dependencies:
     accepts "~1.3.5"
     array-flatten "1.1.1"
-    body-parser "1.18.2"
+    body-parser "1.18.3"
     content-disposition "0.5.2"
     content-type "~1.0.4"
     cookie "0.3.1"
@@ -2227,10 +2260,10 @@ express@^4.16.3:
     on-finished "~2.3.0"
     parseurl "~1.3.2"
     path-to-regexp "0.1.7"
-    proxy-addr "~2.0.3"
-    qs "6.5.1"
+    proxy-addr "~2.0.4"
+    qs "6.5.2"
     range-parser "~1.2.0"
-    safe-buffer "5.1.1"
+    safe-buffer "5.1.2"
     send "0.16.2"
     serve-static "1.13.2"
     setprototypeof "1.1.0"
@@ -2324,10 +2357,10 @@ figlet@^1.1.1:
   resolved "https://registry.yarnpkg.com/figlet/-/figlet-1.2.0.tgz#6c46537378fab649146b5a6143dda019b430b410"
   integrity sha1-bEZTc3j6tkkUa1phQ92gGbQwtBA=
 
-file-stream-rotator@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.3.1.tgz#605ffb1195814eab84cb57040e0ae401a77791f8"
-  integrity sha512-Vr6M5qmomoyJyjGEpvMJd74HWXe/6D1eB342QwJpb0WenGaBhe3IhzJQWzcKIEq5O3yYum45r4lYsQAm7cO1yA==
+file-stream-rotator@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.4.1.tgz#09f67b86d6ea589d20b7852c51c59de55d916d6d"
+  integrity sha512-W3aa3QJEc8BS2MmdVpQiYLKHj3ijpto1gMDlsgCRSKfIUe6MwkcpODGPQ3vZfb0XvCeCqlu9CBQTN7oQri2TZQ==
   dependencies:
     moment "^2.11.2"
 
@@ -2898,6 +2931,16 @@ http-errors@1.6.2, http-errors@~1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
+http-errors@1.6.3, http-errors@~1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -2911,6 +2954,13 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
   integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
+
+iconv-lite@0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  integrity sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@^0.4.4:
   version "0.4.21"
@@ -2971,10 +3021,10 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
-ipaddr.js@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b"
-  integrity sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=
+ipaddr.js@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
+  integrity sha1-6qM9bd16zo9/b+DJygRA5wZzix4=
 
 is-absolute@^1.0.0:
   version "1.0.0"
@@ -3880,14 +3930,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-"node-logger@git+https://github.com/eldeni/node-logger.git":
-  version "0.0.1"
-  resolved "git+https://github.com/eldeni/node-logger.git#1246e95cc97036f7ddde1e9cc77c42814d3aa197"
-  dependencies:
-    chalk "^2.4.1"
-    winston "3"
-    winston-daily-rotate-file "^3.3.3"
-
 node-pre-gyp@0.6.36:
   version "0.6.36"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
@@ -4013,9 +4055,9 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-hash@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
-  integrity sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
 object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
@@ -4419,13 +4461,13 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
-proxy-addr@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
-  integrity sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==
+proxy-addr@~2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
+  integrity sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==
   dependencies:
     forwarded "~0.1.2"
-    ipaddr.js "1.6.0"
+    ipaddr.js "1.8.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -4459,6 +4501,11 @@ qs@6.5.1, qs@~6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
+qs@6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
 range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
@@ -4472,6 +4519,16 @@ raw-body@2.3.2:
     bytes "3.0.0"
     http-errors "1.6.2"
     iconv-lite "0.4.19"
+    unpipe "1.0.0"
+
+raw-body@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
+  integrity sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.3"
+    iconv-lite "0.4.23"
     unpipe "1.0.0"
 
 rc@^1.1.7:
@@ -4503,7 +4560,7 @@ read-pkg@^1.0.0:
 
 readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
-  resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
   dependencies:
     core-util-is "~1.0.0"
@@ -4762,22 +4819,15 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-"route-mapping@git+https://github.com/node-starter-kit/route-mapping.git":
-  version "0.0.1"
-  resolved "git+https://github.com/node-starter-kit/route-mapping.git#94b663e71b80dd1f69aece94e0a36ebcee40bccc"
-  dependencies:
-    "@types/express" "^4.16.0"
-    typescript "^3.1.6"
-
-safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-  integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+  integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -4786,7 +4836,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -4813,7 +4863,7 @@ semver@4.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
   integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
 
-semver@^5.5.0:
+semver@^5.5.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -5111,6 +5161,11 @@ static-extend@^0.1.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
   integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
+
+"statuses@>= 1.4.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
 stream-exhaust@^1.0.1:
   version "1.0.2"
@@ -5814,14 +5869,14 @@ winston-compat@^0.1.4:
     logform "^1.6.0"
     triple-beam "^1.2.0"
 
-winston-daily-rotate-file@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-3.3.3.tgz#b57adeac75edd1c89dd9e37bfcc9d666d33c2db7"
-  integrity sha512-qYE6PcSmYB+nS+BTTzXoDt/TgUI5qV7Rf3X0bB2ZCJq1Tr5vqb3fuqkODJ7epT9H2jFNpSmGkG63sFCAQrDP/g==
+winston-daily-rotate-file@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-3.5.1.tgz#38249976dc5326afa7f3a1e4a39a8211f349e2fe"
+  integrity sha512-Y5CECbcJro55HWcWJSzI1DiQrbrfwwvKHdCCJn9wWsWCGfnCPDl5SWIokS2M0EvOKtbZUrlm5DPG522mvjdUBQ==
   dependencies:
-    file-stream-rotator "^0.3.1"
+    file-stream-rotator "^0.4.1"
     object-hash "^1.3.0"
-    semver "^5.5.0"
+    semver "^5.6.0"
     triple-beam "^1.3.0"
     winston-compat "^0.1.4"
     winston-transport "^4.2.0"
@@ -5839,21 +5894,6 @@ winston-transport@^4.2.0:
     readable-stream "^2.3.6"
     triple-beam "^1.2.0"
 
-winston@3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.1.0.tgz#80724376aef164e024f316100d5b178d78ac5331"
-  integrity sha512-FsQfEE+8YIEeuZEYhHDk5cILo1HOcWkGwvoidLrDgPog0r4bser1lEIOco2dN9zpDJ1M88hfDgZvxe5z4xNcwg==
-  dependencies:
-    async "^2.6.0"
-    diagnostics "^1.1.1"
-    is-stream "^1.1.0"
-    logform "^1.9.1"
-    one-time "0.0.4"
-    readable-stream "^2.3.6"
-    stack-trace "0.0.x"
-    triple-beam "^1.3.0"
-    winston-transport "^4.2.0"
-
 winston@3.0.0-rc4:
   version "3.0.0-rc4"
   resolved "https://registry.yarnpkg.com/winston/-/winston-3.0.0-rc4.tgz#2e34e05b1130bae677c79b3ace993d091e678c5f"
@@ -5867,6 +5907,21 @@ winston@3.0.0-rc4:
     stack-trace "0.0.x"
     triple-beam "^1.0.1"
     winston-transport "^3.1.0"
+
+winston@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.1.0.tgz#80724376aef164e024f316100d5b178d78ac5331"
+  integrity sha512-FsQfEE+8YIEeuZEYhHDk5cILo1HOcWkGwvoidLrDgPog0r4bser1lEIOco2dN9zpDJ1M88hfDgZvxe5z4xNcwg==
+  dependencies:
+    async "^2.6.0"
+    diagnostics "^1.1.1"
+    is-stream "^1.1.0"
+    logform "^1.9.1"
+    one-time "0.0.4"
+    readable-stream "^2.3.6"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.2.0"
 
 wkx@^0.4.1:
   version "0.4.5"


### PR DESCRIPTION
- Module alias `@externalModules/` is created.
- Dependency `route-mapping` is renamed `@nodekit/route-mapper`.

Fixes https://github.com/marmoym/marmoym/issues/125

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
