### PR TITLE
chore: add `@nodekit/express-middleware-attach` and upgrade deps

### DIFF
--- a/internals/gulp/gulpfile.js
+++ b/internals/gulp/gulpfile.js
@@ -25,7 +25,7 @@ const Task = {
 };
 
 const buildLog = (tag, ...args) => {
-  console.info(chalk.cyan(`[build - ${tag}]`), util.format(...args));
+  console.info(chalk.cyan(`[gulp>${tag}]`), util.format(...args));
 };
 
 gulp.task(Task.CLEAN, () => {

--- a/package.json
+++ b/package.json
@@ -44,11 +44,12 @@
     "mocha": "^3.4.2",
     "reflect-metadata": "^0.1.12",
     "tslint": "^5.11.0",
-    "typescript": "^3.1.3"
+    "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@nodekit/node-logger": "git+https://github.com/nodekit-org/node-logger.git",
-    "@nodekit/route-mapper": "git+https://github.com/nodekit-org/route-mapper.git",
+    "@nodekit/express-middleware-attach": "git+https://github.com/nodekit-org/express-middleware-attach.git",
+    "@nodekit/node-logger": "git+https://github.com/nodekit-org/node-logger.git#v0.0.3",
+    "@nodekit/express-route-mapper": "git+https://github.com/nodekit-org/express-route-mapper.git#v0.0.3",
     "bcrypt": "^1.0.3",
     "body-parser": "^1.17.1",
     "chalk": "^2.4.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,21 +3,20 @@
  */
 import "reflect-metadata";
 
-import * as express from 'express';
+import attach from '@nodekit/express-middleware-attach';
+import express from "express";
 
 import { initializeDB } from '@entities/db';
-import LaunchStatus from '@constants/LaunchStatus';
 import { expressLog } from '@modules/Log';
+import LaunchStatus from '@constants/LaunchStatus';
 import marmoymConfig from '@config/marmoymConfig';
+import middlewares from './app.middlewares';
 import state from '@src/state';
 import Token from '@externalModules/token/Token';
 
-import attach from '@externalModules/middleware-attach';
-import middlewares from './app.middlewares';
-
 expressLog.info('App is running in NODE_ENV: %s, LOCAL: %s', process.env.NODE_ENV, process.env.LOCAL);
 
-const app: express.Application = express['default']();
+const app = express();
 
 (async function prepareModules() {
   Token.initialize({
@@ -26,15 +25,14 @@ const app: express.Application = express['default']();
   });
 
   const dbIsInitialized = await initializeDB();
+  
   state.update({
     launchStatus: dbIsInitialized ? LaunchStatus.INIT_SUCCESS : LaunchStatus.INIT_ERROR,
   });
-})();
 
-(function defineApp() {
   attach(app, middlewares);
   
-  app.listen(marmoymConfig.app.port, function(err) {
+  app.listen(marmoymConfig.app.port, (err) => {
     if (err) {
       console.error(err);
     }

--- a/src/routes/routers.ts
+++ b/src/routes/routers.ts
@@ -5,7 +5,7 @@ import {
   Response,
   Router,
 } from 'express';
-import { createRouter } from '@nodekit/route-mapper';
+import { createRouter } from '@nodekit/express-route-mapper';
 
 import ApiResult from '@models/ApiResult';
 import { API } from '@models/ApiURL';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": false,
     "allowJs": true,
     "baseUrl": "./",
-    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,22 +736,28 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@nodekit/node-logger@git+https://github.com/nodekit-org/node-logger.git":
+"@nodekit/express-middleware-attach@git+https://github.com/nodekit-org/express-middleware-attach.git":
   version "0.0.1"
-  resolved "git+https://github.com/nodekit-org/node-logger.git#6b4472010544cb590a0a8bb19fd2fbdfbbec4935"
+  resolved "git+https://github.com/nodekit-org/express-middleware-attach.git#ce49a5f59d91cea75532a7bc9501aec59c7e5598"
+  dependencies:
+    "@types/express" "^4.16.0"
+
+"@nodekit/express-route-mapper@git+https://github.com/nodekit-org/express-route-mapper.git#v0.0.3":
+  version "0.0.3"
+  resolved "git+https://github.com/nodekit-org/express-route-mapper.git#d8c9c6361bdb92cdb0057981d2f292df5875984b"
+  dependencies:
+    "@types/express" "^4.16.0"
+    typescript "^3.1.6"
+
+"@nodekit/node-logger@git+https://github.com/nodekit-org/node-logger.git#v0.0.3":
+  version "0.0.3"
+  resolved "git+https://github.com/nodekit-org/node-logger.git#5721f3c0274a8d251b4f7fdc5077e340cb40655e"
   dependencies:
     chalk "^2.4.1"
     triple-beam "^1.3.0"
     typescript "^3.1.6"
     winston "^3.1.0"
     winston-daily-rotate-file "^3.5.1"
-
-"@nodekit/route-mapper@git+https://github.com/nodekit-org/route-mapper.git":
-  version "0.0.2"
-  resolved "git+https://github.com/nodekit-org/route-mapper.git#647aef20a297867d0761d247bbcfb200204011a4"
-  dependencies:
-    "@types/express" "^4.16.0"
-    typescript "^3.1.6"
 
 "@types/body-parser@*":
   version "1.16.8"
@@ -5564,11 +5570,6 @@ typeorm@^0.2.5:
     xml2js "^0.4.17"
     yargonaut "^1.1.2"
     yargs "^11.1.0"
-
-typescript@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
-  integrity sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
 
 typescript@^3.1.6:
   version "3.1.6"


### PR DESCRIPTION
- Some of the dependencies are upgraded.
- gulp logging is slightly modified. (tag)
- `esModuleInterop` is added to tsconfig

Fixes https://github.com/marmoym/marmoym/issues/128

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
