### PR TITLE
refactor: rename module aliases in order to keep from name collision

### DIFF
--- a/internals/babel/.babelrc.js
+++ b/internals/babel/.babelrc.js
@@ -3,18 +3,18 @@ module.exports = {
     [
       "module-resolver", {
         "alias": {
-          "@config": "./src/config",
-          "@constants": "./src/constants",
-          "@daos": "./src/daos",
-          "@entities": "./src/entities",
-          "@externalModules": "./src/externalModules",
-          "@middlewares": "./src/middlewares",
-          "@models": "./src/models",
-          "@modules": "./src/modules",
-          "@routes": "./src/routes",
-          "@services": "./src/services",
-          "@src": "./src",
-          "@utils": "./src/utils"
+          "@@config": "./src/config",
+          "@@constants": "./src/constants",
+          "@@daos": "./src/daos",
+          "@@entities": "./src/entities",
+          "@@externalModules": "./src/externalModules",
+          "@@middlewares": "./src/middlewares",
+          "@@models": "./src/models",
+          "@@modules": "./src/modules",
+          "@@routes": "./src/routes",
+          "@@services": "./src/services",
+          "@@src": "./src",
+          "@@utils": "./src/utils"
         }
       }
     ],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@nodekit/express-middleware-attach": "git+https://github.com/nodekit-org/express-middleware-attach.git",
+    "@nodekit/express-middleware-attach": "git+https://github.com/nodekit-org/express-middleware-attach.git#v0.0.2",
     "@nodekit/express-route-mapper": "git+https://github.com/nodekit-org/express-route-mapper.git#v0.0.4",
     "@nodekit/node-logger": "git+https://github.com/nodekit-org/node-logger.git#v0.0.3",
     "bcrypt": "^1.0.3",

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,12 +6,12 @@ import "reflect-metadata";
 import attach from '@nodekit/express-middleware-attach';
 import express from "express";
 
-import { initializeDB } from '@entities/db';
-import { expressLog } from '@modules/Log';
-import LaunchStatus from '@constants/LaunchStatus';
-import marmoymConfig from '@config/marmoymConfig';
-import middlewares from '@middlewares/app.middlewares';
-import state from '@models/state';
+import { initializeDB } from '@@entities/db';
+import { expressLog } from '@@modules/Log';
+import LaunchStatus from '@@constants/LaunchStatus';
+import marmoymConfig from '@@config/marmoymConfig';
+import middlewares from '@@middlewares/app.middlewares';
+import state from '@@models/state';
 
 expressLog.info('App is running in NODE_ENV: %s, LOCAL: %s', process.env.NODE_ENV, process.env.LOCAL);
 

--- a/src/daos/UserDAO.ts
+++ b/src/daos/UserDAO.ts
@@ -1,4 +1,4 @@
-import db from '@entities/db';
+import db from '@@entities/db';
 
 const { User } = db;
 

--- a/src/entities/db.ts
+++ b/src/entities/db.ts
@@ -2,9 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import Sequelize from 'sequelize';
 
-import { dbLog } from '@modules/Log';
-import marmoymConfig from '@config/marmoymConfig';
-import * as paths from '@src/paths';
+import { dbLog } from '@@modules/Log';
+import marmoymConfig from '@@config/marmoymConfig';
+import * as paths from '@@src/paths';
 
 const basename = path.basename(__filename);
 const db: DB = {

--- a/src/middlewares/app.middlewares.ts
+++ b/src/middlewares/app.middlewares.ts
@@ -2,14 +2,14 @@ import * as bodyParser from "body-parser";
 import cookieParser from 'cookie-parser';
 import { MiddlewareDefinition } from '@nodekit/express-middleware-attach';
 
-import { API } from '@models/ApiURL';
-import corsHandler from '@middlewares/corsHandler';
-import errorHandler from '@middlewares/errorHandler';
-import httpLogger from "@middlewares/httpLogger";
-import launchStatusChecker from '@middlewares/launchStatusChecker';
-import routeNoMatchHandler from '@middlewares/routeNoMatchHandler';
-import routers from '@routes/routers';
-import state from '@models/state';
+import { API } from '@@models/ApiURL';
+import corsHandler from '@@middlewares/corsHandler';
+import errorHandler from '@@middlewares/errorHandler';
+import httpLogger from '@@middlewares/httpLogger';
+import launchStatusChecker from '@@middlewares/launchStatusChecker';
+import routeNoMatchHandler from '@@middlewares/routeNoMatchHandler';
+import routers from '@@routes/routers';
+import state from '@@models/state';
 
 const middlewareDefinitions: MiddlewareDefinition[] = [
   {

--- a/src/middlewares/corsHandler.ts
+++ b/src/middlewares/corsHandler.ts
@@ -6,8 +6,8 @@ import {
   RequestHandler
  } from 'express';
 
-import marmoymConfig from '@config/marmoymConfig';
-import { expressLog } from '@modules/Log';
+import marmoymConfig from '@@config/marmoymConfig';
+import { expressLog } from '@@modules/Log';
 
 export default function corsHandlerWrapper(): RequestHandler {
   expressLog.info('corsHandler() with: %o', marmoymConfig.cors);

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import { format } from 'util';
 
-import AppError from '@models/AppError';
-import { expressLog } from '@modules/Log';
-import HttpStatus from '@constants/HttpStatus';
-import { isProduction } from '@src/env';
-import ResponseType from '@models/ResponseType';
+import AppError from '@@models/AppError';
+import { expressLog } from '@@modules/Log';
+import HttpStatus from '@@constants/HttpStatus';
+import { isProduction } from '@@src/env';
+import ResponseType from '@@models/ResponseType';
 
 export default function errorHandler(err: Error, req, res, next) {
   try {

--- a/src/middlewares/httpLogger.ts
+++ b/src/middlewares/httpLogger.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 
-import { httpLog } from '@modules/Log';
+import { httpLog } from '@@modules/Log';
 
 const FORMAT = '%s - params: %j, body: %j, user-agent: %j';
 

--- a/src/middlewares/launchStatusChecker.ts
+++ b/src/middlewares/launchStatusChecker.ts
@@ -5,10 +5,10 @@ import {
   Response, 
 } from 'express';
 
-import { expressLog } from '@modules/Log';
-import LaunchStatus from '@constants/LaunchStatus';
-import ResponseType from '@models/ResponseType';
-import { State } from '@models/state';
+import { expressLog } from '@@modules/Log';
+import LaunchStatus from '@@constants/LaunchStatus';
+import ResponseType from '@@models/ResponseType';
+import { State } from '@@models/state';
 
 export default function launchStatusCheckerWrapper(state: State): RequestHandler {
   expressLog.info('[launchStatusChecker] create checker with state: %o', state);

--- a/src/middlewares/routeNoMatchHandler.ts
+++ b/src/middlewares/routeNoMatchHandler.ts
@@ -1,8 +1,8 @@
 import { Request, Response, NextFunction } from  'express';
 
-import { expressLog } from '@modules/Log';
-import AppError from '@models/AppError';
-import ResponseType from '@models/ResponseType';
+import { expressLog } from '@@modules/Log';
+import AppError from '@@models/AppError';
+import ResponseType from '@@models/ResponseType';
 
 export default function routeNoMatchHandlerr(req: Request, res: Response, next: NextFunction) {
   next(AppError.of({

--- a/src/middlewares/tokenHandler.ts
+++ b/src/middlewares/tokenHandler.ts
@@ -1,10 +1,10 @@
 import { NextFunction, Request, Response } from 'express';
 
-import AppError from "@models/AppError";
-import { expressLog } from '@modules/Log';
-import marmoymConfig from '@config/marmoymConfig';
-import ResponseType from '@models/ResponseType';
-import Token from '@modules/Token';
+import AppError from '@@models/AppError';
+import { expressLog } from '@@modules/Log';
+import marmoymConfig from '@@config/marmoymConfig';
+import ResponseType from '@@models/ResponseType';
+import Token from '@@modules/Token';
 
 export default function tokenAuthHandler(req: Request, res: Response, next: NextFunction) {
   const token = req.cookies['auth-token'];

--- a/src/migrate/seed/seed.180725.ts
+++ b/src/migrate/seed/seed.180725.ts
@@ -1,7 +1,7 @@
-// import Definition from '@entities/Definition';
-// import Term from '@entities/Term';
-// import User from '@entities/User';
-// import Vote from '@entities/Vote';
+// import Definition from '@@entities/Definition';
+// import Term from '@@entities/Term';
+// import User from '@@entities/User';
+// import Vote from '@@entities/Vote';
 
 // const term1 = new Term({
 //   label: 'term0',

--- a/src/models/ApiResult.ts
+++ b/src/models/ApiResult.ts
@@ -1,4 +1,4 @@
-import Cookie from '@models/Cookie';
+import Cookie from '@@models/Cookie';
 
 const COOKIES = Symbol('cookies');
 

--- a/src/models/AppError.ts
+++ b/src/models/AppError.ts
@@ -2,7 +2,7 @@ import { format } from 'util';
 
 import { 
   ResponseTypeEntry,
-} from '@models/ResponseType';
+} from '@@models/ResponseType';
 
 export default class AppError extends Error {
   public code: number;

--- a/src/models/state.ts
+++ b/src/models/state.ts
@@ -1,5 +1,5 @@
-import LaunchStatus from '@constants/LaunchStatus';
-import { stateLog } from '@modules/Log';
+import LaunchStatus from '@@constants/LaunchStatus';
+import { stateLog } from '@@modules/Log';
 
 const state: State = {
   launchStatus: LaunchStatus.NOT_YET_INTIALIZED,

--- a/src/models/vote/VoteParam.ts
+++ b/src/models/vote/VoteParam.ts
@@ -1,4 +1,4 @@
-// import ApiParam from '@models/ApiParam';
+// import ApiParam from '@@models/ApiParam';
 
 // /**
 //  * @deprecated

--- a/src/modules/Log.ts
+++ b/src/modules/Log.ts
@@ -1,7 +1,7 @@
 import * as NodeLogger from '@nodekit/node-logger';
 
 import chalk from 'chalk';
-import * as paths from '@src/paths';
+import * as paths from '@@src/paths';
 
 const nodeLogger = NodeLogger.createLogger({
   logPath: paths.logs,

--- a/src/modules/Token.ts
+++ b/src/modules/Token.ts
@@ -1,6 +1,6 @@
-import token from '@externalModules/token';
+import token from '@@externalModules/token';
 
-import marmoymConfig from '@config/marmoymConfig';
+import marmoymConfig from '@@config/marmoymConfig';
 
 const Token = new token({
   privateKey: marmoymConfig.auth.privateKey,

--- a/src/routes/default/routes.default.ts
+++ b/src/routes/default/routes.default.ts
@@ -1,8 +1,8 @@
 import { Router, Request, Response } from 'express';
 
-import ApiURL from '@models/ApiURL';
-import * as DebugService from '@services/debugService';
-import HttpMethod from '@constants/HttpMethod';
+import ApiURL from '@@models/ApiURL';
+import * as DebugService from '@@services/debugService';
+import HttpMethod from '@@constants/HttpMethod';
 // import { Route } from '../routes';
 
 const routeMap = [

--- a/src/routes/routers.ts
+++ b/src/routes/routers.ts
@@ -7,13 +7,13 @@ import {
 } from 'express';
 import { createRouter } from '@nodekit/express-route-mapper';
 
-import ApiResult from '@models/ApiResult';
-import { API } from '@models/ApiURL';
-import AppError from '@models/AppError';
-import Cookie from '@models/Cookie';
-import HttpStatus from '@constants/HttpStatus';
-import { expressLog } from '@modules/Log';
-import ResponseType from '@models/ResponseType';
+import ApiResult from '@@models/ApiResult';
+import { API } from '@@models/ApiURL';
+import AppError from '@@models/AppError';
+import Cookie from '@@models/Cookie';
+import HttpStatus from '@@constants/HttpStatus';
+import { expressLog } from '@@modules/Log';
+import ResponseType from '@@models/ResponseType';
 import routesDefault from './default/routes.default';
 import routesV1 from './v1/routes.v1';
 

--- a/src/routes/v1/routes.v1.ts
+++ b/src/routes/v1/routes.v1.ts
@@ -1,14 +1,14 @@
 import { Request, Response, NextFunction } from 'express';
 
-import ApiURL from '@models/ApiURL';
+import ApiURL from '@@models/ApiURL';
 import definitionService, { 
-} from '@services/definitionService';
-import HttpMethod from '@constants/HttpMethod';
-// import * as migrateService from '@services/migrateService';
-import { optional, requireNonEmpty } from '@src/utils/objectUtils';
-import { Route } from '@routes/routers';
-import * as userService from '@services/userService';
-import tokenAuthHandler from '@middlewares/tokenHandler';
+} from '@@services/definitionService';
+import HttpMethod from '@@constants/HttpMethod';
+// import * as migrateService from '@@services/migrateService';
+import { optional, requireNonEmpty } from '@@src/utils/objectUtils';
+import { Route } from '@@routes/routers';
+import * as userService from '@@services/userService';
+import tokenAuthHandler from '@@middlewares/tokenHandler';
 
 const pathOrderedRouteMap: Route[] = [
   // {

--- a/src/services/debugService.ts
+++ b/src/services/debugService.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 
-import ApiResult from '@models/ApiResult';
+import ApiResult from '@@models/ApiResult';
 
 export async function getDebug() {
   return new ApiResult({

--- a/src/services/definitionService.ts
+++ b/src/services/definitionService.ts
@@ -1,4 +1,4 @@
-import ApiResult from '@models/ApiResult';
+import ApiResult from '@@models/ApiResult';
 
 const definitionService = {
   async addDefinition(param: {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,6 +1,6 @@
-import ApiResult from '@models/ApiResult';
-import Token from '@modules/Token';
-import * as UserDAO from '@daos/UserDAO';
+import ApiResult from '@@models/ApiResult';
+import Token from '@@modules/Token';
+import * as UserDAO from '@@daos/UserDAO';
 
 export const signUpUser: SignInUser = async function ({
   password,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,40 +9,40 @@
     "moduleResolution": "node",
     "noEmit": true,
     "paths": {
-      "@config/*": [
+      "@@config/*": [
         "src/config/*" 
       ],
-      "@constants/*": [
+      "@@constants/*": [
         "src/constants/*"
       ],
-      "@daos/*": [
+      "@@daos/*": [
         "src/daos/*"
       ],
-      "@entities/*": [
+      "@@entities/*": [
         "src/entities/*"
       ],
-      "@externalModules/*": [
+      "@@externalModules/*": [
         "src/externalModules/*"
       ],
-      "@middlewares/*": [
+      "@@middlewares/*": [
         "src/middlewares/*"
       ],
-      "@models/*": [
+      "@@models/*": [
         "src/models/*"
       ],
-      "@modules/*": [
+      "@@modules/*": [
         "src/modules/*"
       ],
-      "@routes/*": [
+      "@@routes/*": [
         "src/routes/*"
       ],
-      "@services/*": [
+      "@@services/*": [
         "src/services/*"
       ],
-      "@src/*": [
+      "@@src/*": [
         "src/*"
       ],
-      "@utils/*": [
+      "@@utils/*": [
         "src/utils/*"
       ]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,9 +736,9 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@nodekit/express-middleware-attach@git+https://github.com/nodekit-org/express-middleware-attach.git":
-  version "0.0.1"
-  resolved "git+https://github.com/nodekit-org/express-middleware-attach.git#ce49a5f59d91cea75532a7bc9501aec59c7e5598"
+"@nodekit/express-middleware-attach@git+https://github.com/nodekit-org/express-middleware-attach.git#v0.0.2":
+  version "0.0.2"
+  resolved "git+https://github.com/nodekit-org/express-middleware-attach.git#4d5244cf914dc995be68ca019a9a7b530d8c91e5"
   dependencies:
     "@types/express" "^4.16.0"
 


### PR DESCRIPTION
- npm module can have `@ORG/NAME_MODULE` names. Module aliases are thus named
with `@@-` in order to prevent collision.
- `@nodekit/express-middleware-attach` is upgraded.

Fixes https://github.com/marmoym/marmoym/issues/131

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
