### PR TITLE
feat: statically type each different route

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@nodekit/express-middleware-attach": "git+https://github.com/nodekit-org/express-middleware-attach.git#v0.0.2",
-    "@nodekit/express-route-mapper": "git+https://github.com/nodekit-org/express-route-mapper.git#v0.0.4",
+    "@nodekit/express-route-mapper": "git+https://github.com/nodekit-org/express-route-mapper.git#v0.0.5",
     "@nodekit/node-logger": "git+https://github.com/nodekit-org/node-logger.git#v0.0.3",
     "bcrypt": "^1.0.3",
     "body-parser": "^1.17.1",

--- a/src/models/params/UserSignUpParam.ts
+++ b/src/models/params/UserSignUpParam.ts
@@ -1,0 +1,4 @@
+export default class UserSignUpParam {
+  password;
+  userId;
+}

--- a/src/routes/routers.ts
+++ b/src/routes/routers.ts
@@ -34,14 +34,14 @@ function validatePayload(req: Request, res: Response, next: NextFunction) {
   return function (apiResult: ApiResult<any>) {
     if (apiResult === undefined) {
       throw AppError.of({
-        type: ResponseType.RESPONSE_NOT_PROVIDED,
+        responseType: ResponseType.RESPONSE_NOT_PROVIDED,
       });
     }
 
     if (!(apiResult instanceof ApiResult)) {
       throw AppError.of({
         args: [ apiResult ],
-        type: ResponseType.RESPONSE_TYPE_NOT_API_RESULT,
+        responseType: ResponseType.RESPONSE_TYPE_NOT_API_RESULT,
       });
     }
 
@@ -79,10 +79,10 @@ function respond(req: Request, res: Response, next: NextFunction) {
   }
 }
 
-export interface Route {
-  action: (x: object | null) => Promise<ApiResult<any>>;
+export interface Route<P> {
+  action: (param: P) => Promise<ApiResult<any>>;
   beforeware?: Array<(Request: any, res: Response, next: NextFunction) => void>;
-  createParam?: (req: Request) => object;
+  createParam?: (req: Request) => P;
   method: 'get' | 'post' | 'put' | 'delete';
   path: string;
 }

--- a/src/routes/v1/routes.v1.ts
+++ b/src/routes/v1/routes.v1.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 
+import ApiResult from '@@models/ApiResult';
 import ApiURL from '@@models/ApiURL';
 import definitionService, { 
 } from '@@services/definitionService';
@@ -8,9 +9,10 @@ import HttpMethod from '@@constants/HttpMethod';
 import { optional, requireNonEmpty } from '@@src/utils/objectUtils';
 import { Route } from '@@routes/routers';
 import * as userService from '@@services/userService';
+import UserSignUpParam from '@@models/params/UserSignUpParam';
 import tokenAuthHandler from '@@middlewares/tokenHandler';
 
-const pathOrderedRouteMap: Route[] = [
+const pathOrderedRouteMap: Route<any>[] = [
   // {
   //   action: migrateService.seed,
   //   method: HttpMethod.GET,
@@ -64,7 +66,7 @@ const pathOrderedRouteMap: Route[] = [
     method: HttpMethod.POST,
     path: ApiURL.DEFINITION_NEW,
   },
-  {
+  <Route<UserSignUpParam>>{
     action: userService.signUpUser,
     createParam: (req: Request) => {
       return {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -27,5 +27,5 @@ interface SignInUser {
   (param: {
     password: string;
     userId: string;
-  }): Promise<ApiResult<any | undefined>>;
+  }): Promise<ApiResult<any>>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,9 +742,9 @@
   dependencies:
     "@types/express" "^4.16.0"
 
-"@nodekit/express-route-mapper@git+https://github.com/nodekit-org/express-route-mapper.git#v0.0.4":
-  version "0.0.4"
-  resolved "git+https://github.com/nodekit-org/express-route-mapper.git#f40295a42818829e6ece87819d4811b189cfd3ac"
+"@nodekit/express-route-mapper@git+https://github.com/nodekit-org/express-route-mapper.git#v0.0.5":
+  version "0.0.5"
+  resolved "git+https://github.com/nodekit-org/express-route-mapper.git#8a53a733fbb990e8fbb125eb8cdd4a536759da6f"
   dependencies:
     "@types/express" "^4.16.0"
     typescript "^3.1.6"


### PR DESCRIPTION
- dep `express-route-mapper` is upgraded.
- `params/` under model is created. This is the path where we store API param
models.
- By type casting in front of each route object, we do the static typing.

Fixes https://github.com/marmoym/marmoym/issues/133

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
